### PR TITLE
Add support of Environment Variables Import

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,8 @@ The configuration file utilizes YAML objects to describe the secret literals, wh
 | accessModifier   | String                    | The access-level modifier of the generated Swift property containing obfuscated secret literal's data. The supported values are `internal` and `public`. If not specified, the top-level `defaultAccessModifier` value is used. See [Access control](#access-control) section for usage details. |
 | name             | String                    | The name of the generated Swift property containing obfuscated secret literal's data. This value is used as-is, without validity checking. Thus, make sure to use a valid property name.<br/><sub>**Required.**</sub> | 
 | namespace        | String                    | The namespace in which to enclose the generated secret literal declaration. See [Namespaces](#namespaces) section for usage details. |
-| value            | String or List of strings | The plain value of the secret literal, which is to be obfuscated. The YAML data types are mapped to `String` and `Array<String>` in Swift, respectively.<br/><sub>**Required.**</sub> |
+| environmentKey   | String                    | The environment variable name to be used to retrieve the plain value of the secret literal. If not specified, the `value` is used. |
+| value            | String or List of strings | The plain value of the secret literal, which is to be obfuscated. The YAML data types are mapped to `String` and `Array<String>` in Swift, respectively.<br/><sub>**Required if `environmentKey` is not specified.**</sub> |
 
 <details>
 <summary><strong>Example secret definition</strong></summary>

--- a/Sources/ConfidentialCore/Extensions/Foundation/CodingUserInfoKey/CodingUserInfoKey+Environment.swift
+++ b/Sources/ConfidentialCore/Extensions/Foundation/CodingUserInfoKey/CodingUserInfoKey+Environment.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+extension CodingUserInfoKey {
+    public static let processInfoEnvironment = CodingUserInfoKey(rawValue: "processInfoEnvironment")!
+}

--- a/Sources/swift-confidential/Subcommands/Obfuscate.swift
+++ b/Sources/swift-confidential/Subcommands/Obfuscate.swift
@@ -38,7 +38,13 @@ extension SwiftConfidential {
             }
 
             let configurationYAML = try Data(contentsOf: configuration)
-            let configuration = try YAMLDecoder().decode(Configuration.self, from: configurationYAML)
+            let configuration = try YAMLDecoder().decode(
+                Configuration.self,
+                from: configurationYAML,
+                userInfo: [
+                    CodingUserInfoKey.processInfoEnvironment:  ProcessInfo.processInfo.environment
+                ]
+            )
 
             var sourceSpecification = try Parsers.ModelTransform.SourceSpecification()
                 .parse(configuration)


### PR DESCRIPTION
This PR introduce `Configuration.Secret` support for fetching raw values from Environment. It is benefitial to keep secrets outside git repository