### PR TITLE
Support for Swift 6-style `internal import`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
           - macos: 14
             xcode: '15.4'  # Swift 5.10
             upload_coverage: true
+          - macos: 14
+            xcode: '16.0'  # Swift 6.0
+            upload_coverage: false
 
     steps:
       - name: Runner Overview

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The table below lists the keys to include in the configuration file along with t
 | defaultAccessModifier    | String              | The default access-level modifier applied to each generated secret literal, unless the secret definition states otherwise. The default value is `internal`. See [Access control](#access-control) section for usage details. |
 | defaultNamespace         | String              | The default namespace in which to enclose all the generated secret literals without explicitly assigned namespace. The default value is `extend Obfuscation.Secret from ConfidentialKit`. See [Namespaces](#namespaces) section for usage details. |
 | implementationOnlyImport | Boolean             | Specifies whether to generate implementation-only `ConfidentialKit` import. The default value is `false`. See [Building libraries for distribution](#building-libraries-for-distribution) section for usage details. |
+| internalImport           | Boolean             | Specifies whether to generate internal `ConfidentialKit` import. The default value is `false`. See [Building libraries for distribution](#building-libraries-for-distribution) section for usage details. |
 | secrets                  | List of objects     | The list of objects defining the secret literals to be obfuscated. See [Secrets](#secrets) section for usage details.<br/><sub>**Required.**</sub> |
 
 <details>
@@ -429,10 +430,12 @@ Additionally, if you need more fine-grained control, you can override `defaultAc
 
 ### Building libraries for distribution
 
-By default, Swift Confidential does not annotate the generated `ConfidentialKit` import with `@_implementationOnly` attribute. However, there are cases, such as when [creating an XCFramework bundle](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle), in which you should use implementation-only imports to avoid exposing internal symbols to your library consumers. To enable implementation-only `ConfidentialKit` import, set `implementationOnlyImport` configuration option to `true`.
+By default, Swift Confidential does not annotate the generated `ConfidentialKit` import with `@_implementationOnly` or `internal`. However, there are cases, such as when [creating an XCFramework bundle](https://developer.apple.com/documentation/xcode/creating-a-multi-platform-binary-framework-bundle), in which you should use this style of imports to avoid exposing internal symbols to consumers of your library. To enable this:
+- Swift 6: set the `internalImport` configuration option to `true`.
+- Swift 5 and earlier: set the `implementationOnlyImport` configuration option to `true`.
 
 > [!IMPORTANT]  
-> The implementation-only imports are applicable for types used only internally, thus it is an error to enable `implementationOnlyImport` if either of the secrets has access level set to `public`. Also note that setting the `implementationOnlyImport` option to `true` does not imply implementation-only imports for extended namespaces.
+> The implementation-only / internal imports are applicable for types used only internally, thus it is an error to enable `implementationOnlyImport` or `internalImport` if either of the secrets has access level set to `public`. Also note that setting either of these options to `true` does not affect imports for extended namespaces. Furthermore, note that only one of `implementationOnlyImport` and `internalImport` can take affect, and the `internalImport` will supercede the former, if they are both present.
 
 ### Additional considerations for Confidential Swift Package plugin
 

--- a/Sources/ConfidentialCore/Models/Configuration/Configuration.swift
+++ b/Sources/ConfidentialCore/Models/Configuration/Configuration.swift
@@ -6,6 +6,7 @@ public struct Configuration: Equatable, Decodable {
     var defaultAccessModifier: String?
     var defaultNamespace: String?
     var implementationOnlyImport: Bool?
+    var internalImport: Bool?
     var secrets: ArraySlice<Secret>
 }
 // swiftlint:enable discouraged_optional_boolean
@@ -19,6 +20,7 @@ public extension Configuration {
             defaultAccessModifier: try container.decodeIfPresent(String.self, forKey: .defaultAccessModifier),
             defaultNamespace: try container.decodeIfPresent(String.self, forKey: .defaultNamespace),
             implementationOnlyImport: try container.decodeIfPresent(Bool.self, forKey: .implementationOnlyImport),
+            internalImport: try container.decodeIfPresent(Bool.self, forKey: .internalImport),
             secrets: try container.decode([Secret].self, forKey: .secrets)[...]
         )
     }
@@ -62,6 +64,7 @@ private extension Configuration {
         case defaultAccessModifier
         case defaultNamespace
         case implementationOnlyImport
+        case internalImport
         case secrets
     }
 }

--- a/Sources/ConfidentialCore/Models/SourceSpecification/SourceSpecification.swift
+++ b/Sources/ConfidentialCore/Models/SourceSpecification/SourceSpecification.swift
@@ -3,8 +3,14 @@ import Foundation
 
 public struct SourceSpecification: Equatable {
     var algorithm: Algorithm
-    var implementationOnlyImport: Bool
+    var importAttribute: ImportAttribute
     var secrets: Secrets
+
+    public enum ImportAttribute {
+        case `default`
+        case implementationOnly
+        case `internal`
+    }
 }
 
 public extension SourceSpecification {

--- a/Sources/ConfidentialCore/Parsing/Parsers/ModelTransform/SourceSpecificationParser.swift
+++ b/Sources/ConfidentialCore/Parsing/Parsers/ModelTransform/SourceSpecificationParser.swift
@@ -19,7 +19,7 @@ where
     public func parse(_ input: inout Configuration) throws -> SourceSpecification {
         let spec = SourceSpecification(
             algorithm: try algorithmParser.parse(&input),
-            implementationOnlyImport: input.implementationOnlyImport ?? false,
+            importAttribute: input.importAttribute,
             secrets: try secretsParser.parse(&input)
         )
         input.defaultAccessModifier = nil
@@ -31,6 +31,13 @@ where
 }
 
 public extension Parsers.ModelTransform {
-
     typealias SourceSpecification = SourceSpecificationParser
+}
+
+extension Configuration {
+    var importAttribute: SourceSpecification.ImportAttribute {
+        if let internalImport, internalImport { return .internal }
+        if let implementationOnlyImport, implementationOnlyImport { return .implementationOnly }
+        return .default
+    }
 }

--- a/Tests/ConfidentialCoreTests/Models/Configuration/ConfigurationTests.swift
+++ b/Tests/ConfidentialCoreTests/Models/Configuration/ConfigurationTests.swift
@@ -57,6 +57,60 @@ final class ConfigurationTests: XCTestCase {
         )
     }
 
+    func test_givenJSONEncodedConfiguration_whenDecodeWithJSONDecoder_thenNoThrowAndReturnsExpectedConfigurationInstance2() {
+        // given
+        let algorithm = ["compress using lz4", "encrypt using aes-128-gcm"]
+        let defaultAccessModifier = "internal"
+        let defaultNamespace = "create Secrets"
+        let internalImport = true
+        let secret1 = ("secret1", "value", "extend Obfuscation.Secret from ConfidentialKit", "public")
+        let secret2 = ("secret2", ["value1", "value2"])
+        let jsonConfiguration = Data(
+        """
+        {
+          "algorithm": [\(algorithm.map { #""\#($0)""# }.joined(separator: ","))],
+          "defaultAccessModifier": "\(defaultAccessModifier)",
+          "defaultNamespace": "\(defaultNamespace)",
+          "internalImport": \(internalImport),
+          "secrets": [
+            { "name": "\(secret1.0)", "value": "\(secret1.1)", "namespace": "\(secret1.2)", "accessModifier": "\(secret1.3)" },
+            { "name": "\(secret2.0)", "value": [\(secret2.1.map { #""\#($0)""# }.joined(separator: ","))] }
+          ]
+        }
+        """.utf8
+        )
+        let decoder = JSONDecoder()
+
+        // when & then
+        var configuration: Configuration?
+        XCTAssertNoThrow(
+            configuration = try decoder.decode(Configuration.self, from: jsonConfiguration)
+        )
+        XCTAssertEqual(
+            Configuration(
+                algorithm: algorithm[...],
+                defaultAccessModifier: defaultAccessModifier,
+                defaultNamespace: defaultNamespace,
+                internalImport: true,
+                secrets: [
+                    .init(
+                        name: secret1.0,
+                        value: .singleValue(secret1.1),
+                        namespace: secret1.2,
+                        accessModifier: secret1.3
+                    ),
+                    .init(
+                        name: secret2.0,
+                        value: .array(secret2.1),
+                        namespace: .none,
+                        accessModifier: .none
+                    )
+                ][...]
+            ),
+            configuration
+        )
+    }
+
     func test_givenInvalidJSONEncodedConfiguration_whenDecodeWithJSONDecoder_thenThrowsError() {
         // given
         let invalidConfigurations = [

--- a/Tests/ConfidentialCoreTests/Parsing/Parsers/CodeGeneration/NamespaceDeclParserTests.swift
+++ b/Tests/ConfidentialCoreTests/Parsing/Parsers/CodeGeneration/NamespaceDeclParserTests.swift
@@ -119,7 +119,7 @@ final class NamespaceDeclParserTests: XCTestCase {
         XCTAssertTrue(membersParserSpy.parseRecordedInput.contains([publicSecretStub]))
         XCTAssertEqual([[]], deobfuscateDataFunctionDeclParserSpy.parseRecordedInput)
         XCTAssertTrue(sourceSpecification.algorithm.isEmpty)
-        XCTAssertFalse(sourceSpecification.implementationOnlyImport)
+        XCTAssertEqual(sourceSpecification.importAttribute, .default)
         XCTAssertTrue(sourceSpecification.secrets.isEmpty)
     }
 }

--- a/Tests/ConfidentialCoreTests/Parsing/Parsers/ModelTransform/SourceSpecificationParserTests.swift
+++ b/Tests/ConfidentialCoreTests/Parsing/Parsers/ModelTransform/SourceSpecificationParserTests.swift
@@ -54,7 +54,7 @@ final class SourceSpecificationParserTests: XCTestCase {
         // then
         let expectedSpecification = SourceSpecification(
             algorithm: algorithmStub,
-            implementationOnlyImport: false,
+            importAttribute: .default,
             secrets: secretsStub
         )
         XCTAssertEqual(expectedSpecification, specification)

--- a/Tests/ConfidentialCoreTests/TestDoubles/Stubs/SourceSpecificationStubFactory.swift
+++ b/Tests/ConfidentialCoreTests/TestDoubles/Stubs/SourceSpecificationStubFactory.swift
@@ -6,12 +6,12 @@ extension SourceSpecification {
 
         static func makeSpecification(
             algorithm: SourceSpecification.Algorithm = [],
-            implementationOnlyImport: Bool = false,
+            importAttribute: SourceSpecification.ImportAttribute = .default,
             secrets: SourceSpecification.Secrets = [:]
         ) -> SourceSpecification {
             .init(
                 algorithm: algorithm,
-                implementationOnlyImport: implementationOnlyImport,
+                importAttribute: importAttribute,
                 secrets: secrets
             )
         }


### PR DESCRIPTION
`@_implementationOnly import` has been deprecated and now produces a compilation warning using the Swift 6 toolchain. The preferred new syntax is `internal import`.

To implement, we add a new flag to the configuration spec, `internalImport` which acts very similarly to `implementationOnlyImport`. Both flags are maintained for backwards compatibility, although `internalImport` supercedes `implementationOnlyImport`.