### PR TITLE
chore: bump yams to 6.0.2 for Swift 6

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
-        "version" : "5.4.0"
+        "revision" : "f4d4d6827d36092d151ad7f6fef1991c1b7192f6",
+        "version" : "6.0.2"
       }
     }
   ],

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -76,7 +76,7 @@ var package = Package(
 package.dependencies.append(contentsOf: [
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.6.1"),
     .package(url: "https://github.com/pointfreeco/swift-parsing.git", from: "0.14.1"),
-    .package(url: "https://github.com/jpsim/Yams.git", from: "5.4.0")
+    .package(url: "https://github.com/jpsim/Yams.git", from: "6.0.2")
 ])
 package.targets.append(contentsOf: [
     // Core Module


### PR DESCRIPTION
Bump Yams to 6.0.2 in the Package for Swift 6.0