### PR TITLE
fix: Adjust GenericArgumentSyntax initialization for SwiftSyntax 601 …

### DIFF
--- a/Sources/ConfidentialKitMacros/SyntaxNodes/Attributes/ObfuscatedAttribute.swift
+++ b/Sources/ConfidentialKitMacros/SyntaxNodes/Attributes/ObfuscatedAttribute.swift
@@ -11,7 +11,11 @@ extension AttributeSyntax {
                 IdentifierTypeSyntax(
                     name: .identifier(C.Code.Generation.obfuscatedMacroFullyQualifiedName),
                     genericArgumentClause: .init {
+                        #if canImport(SwiftSyntax601)
                         GenericArgumentSyntax(argument: .type(plainValueType))
+                        #else
+                        GenericArgumentSyntax(argument: plainValueType)
+                        #endif
                     }
                 )
             )


### PR DESCRIPTION
Resolves issue #13 as  @Arctanyn porposed.

The `GenericArgumentSyntax` initializer's `argument` parameter now expects a `GenericArgumentSyntax.ArgumentType` (e.g., `.type(TypeSyntax)`) in SwiftSyntax 601 and later. 
This conditional compilation ensures continued support across different SwiftSyntax versions.